### PR TITLE
Fix for compilation on intel, and flag POSIX source

### DIFF
--- a/src/bcf_index.c
+++ b/src/bcf_index.c
@@ -1,3 +1,6 @@
+#define _POSIX_C_SOURCE 200112L /* Rsamtools: c99 fileno */
+#define _SVID_SOURCE            /* Rsamtools: c99 strdup */
+
 #include "R.h"
 
 #include <assert.h>

--- a/src/bedidx.c
+++ b/src/bedidx.c
@@ -1,3 +1,6 @@
+#define _POSIX_C_SOURCE 200112L /* Rsamtools: c99 fileno */
+#define _SVID_SOURCE            /* Rsamtools: c99 strdup */
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/knetfile.c
+++ b/src/knetfile.c
@@ -1,3 +1,6 @@
+#define _POSIX_C_SOURCE 200112L /* Rsamtools: c99 fileno */
+#define _SVID_SOURCE            /* Rsamtools: c99 strdup */
+
 /* The MIT License
 
    Copyright (c) 2008 Genome Research Ltd (GRL).

--- a/src/knetfile.c
+++ b/src/knetfile.c
@@ -53,6 +53,14 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+
+
+// Intel compiler needs explicit sys/select.h include
+#ifdef __INTEL_COMPILER
+  #include <sys/select.h>
+#endif
+
+
 #endif
 
 

--- a/src/knetfile.c
+++ b/src/knetfile.c
@@ -53,11 +53,7 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
-
-
-// Intel compiler needs explicit sys/select.h include
-#ifdef __INTEL_COMPILER
-  #include <sys/select.h>
+#include <sys/select.h>
 #endif
 
 

--- a/src/tabix_index.c
+++ b/src/tabix_index.c
@@ -1,3 +1,6 @@
+#define _POSIX_C_SOURCE 200112L /* Rsamtools: c99 fileno */
+#define _SVID_SOURCE            /* Rsamtools: c99 strdup */
+
 #include "R.h"
 
 #include <ctype.h>

--- a/src/vcf.c
+++ b/src/vcf.c
@@ -1,3 +1,6 @@
+#define _POSIX_C_SOURCE 200112L /* Rsamtools: c99 fileno */
+#define _SVID_SOURCE            /* Rsamtools: c99 strdup */
+
 #include "R.h"
 #include <zlib.h>
 #include <stdlib.h>


### PR DESCRIPTION
With intel compiler, knetfile.c requires includ of sys/select.h to build.

Also various samtools code is POSIX, but R is C99 - and might be setup to build packages with -std=c99. Flag the POSIX source files with #define as done by rsamtools:

https://github.com/Bioconductor-mirror/Rsamtools/commit/c70ed5a3b4068aff3af65ca14274ac45b2a28330
