### PR TITLE
Fix bug where only the first range would be checked

### DIFF
--- a/R/seqminer.R
+++ b/R/seqminer.R
@@ -70,7 +70,7 @@ isTabixRange <- function(range) {
     }
     return(TRUE)
   }
-  ranges <- strsplit(x = range, split = ",")[[1]]
+  ranges <- unlist(strsplit(x = range, split = ","))
   sapply(ranges, isValid)
 }
 


### PR DESCRIPTION
Hi! I came across a small bug in `isTabixRange` today which has a very simple fix. This fixes an issue where only the first range would be checked if a vector was supplied.

Current version:

```r
isTabixRange(c("chr1:1-200", "X:1", "1:100-100", "chr1", "1:1-20,1:30-40"))
chr1:1-200 
      TRUE 
```

After change:

```r
isTabixRange(c("chr1:1-200", "X:1", "1:100-100", "chr1", "1:1-20,1:30-40"))
chr1:1-200        X:1  1:100-100       chr1     1:1-20    1:30-40 
      TRUE       TRUE       TRUE       TRUE       TRUE       TRUE
```